### PR TITLE
Update slide_countdown_clock.dart

### DIFF
--- a/lib/slide_countdown_clock.dart
+++ b/lib/slide_countdown_clock.dart
@@ -221,8 +221,8 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
             Container(
               decoration: widget.decoration,
               padding: widget.tightLabel
-                  ? EdgeInsets.only(left: 3)
-                  : EdgeInsets.zero,
+                  ? EdgeInsets.zero
+                  : EdgeInsets.only(left: 3),
               child: Digit<int>(
                 padding: widget.padding,
                 itemStream: timeStream.map<int>(tensDigit),
@@ -236,8 +236,8 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
             Container(
               decoration: widget.decoration,
               padding: widget.tightLabel
-                  ? EdgeInsets.only(right: 3)
-                  : EdgeInsets.zero,
+                  ? EdgeInsets.zero
+                  : EdgeInsets.only(right: 3),
               child: Digit<int>(
                 padding: widget.padding,
                 itemStream: timeStream.map<int>(onesDigit),


### PR DESCRIPTION
Change a conditional so there's no padding when `tightLabel` is true. I think this is more intuitive