### PR TITLE
Add shouldShowHours property

### DIFF
--- a/lib/slide_countdown_clock.dart
+++ b/lib/slide_countdown_clock.dart
@@ -13,31 +13,31 @@ part 'package:slide_countdown_clock/slide_direction.dart';
 class SlideCountdownClock extends StatefulWidget {
   /// The amount of time until the event and `onDone` is called.
   final Duration duration;
-  
+
   /// The style of text used for the digits
   final TextStyle textStyle;
-  
+
   /// The style used for seperator between digits. I.e. `:`, `.`, `,`.
   final TextStyle separatorTextStyle;
-  
+
   /// The character(s) to display between the hour divisions: `10 : 20`
   final String separator;
-  
+
   /// The decoration to place on the container
   final BoxDecoration decoration;
-  
+
   /// The direction in which the numerals move out in and out of view.
   final SlideDirection slideDirection;
-  
+
   /// A callback that is called when the [duration] reaches 0.
   final VoidCallback onDone;
-  
+
   /// The padding around the widget.
   final EdgeInsets padding;
-  
+
   /// True for a label that needs added padding between characters.
   final bool tightLabel;
-  
+
   /// Whether the widget should show another division for days.
   final bool shouldShowDays;
 
@@ -63,13 +63,12 @@ class SlideCountdownClock extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  SlideCountdownClockState createState() =>
-      SlideCountdownClockState(duration, shouldShowDays, shouldShowHours);
+  SlideCountdownClockState createState() => SlideCountdownClockState(duration, shouldShowDays, shouldShowHours);
 }
 
 class SlideCountdownClockState extends State<SlideCountdownClock> {
-  SlideCountdownClockState(Duration duration, bool shouldShowDays, bool shouldShowHours) :
-        this.shouldShowDays = shouldShowDays,
+  SlideCountdownClockState(Duration duration, bool shouldShowDays, bool shouldShowHours)
+      : this.shouldShowDays = shouldShowDays,
         this.shouldShowHours = shouldShowHours {
     timeLeft = duration;
 
@@ -131,9 +130,7 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
       children: <Widget>[
         (shouldShowDays) ? _buildDayDigits() : SizedBox(),
         (shouldShowDays) ? _buildSpace() : SizedBox(),
-        (widget.separator.isNotEmpty && shouldShowDays)
-            ? _buildSeparator()
-            : SizedBox(),
+        (widget.separator.isNotEmpty && shouldShowDays) ? _buildSeparator() : SizedBox(),
         (shouldShowHours) ? _buildHourDigits() : SizedBox(),
         (shouldShowHours) ? _buildSpace() : SizedBox(),
         (widget.separator.isNotEmpty && shouldShowHours) ? _buildSeparator() : SizedBox(),
@@ -171,19 +168,18 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
   }
 
   Widget _buildDigitForLargeNumber(
-      Stream<DateTime> timeStream,
-      List<Function> digits,
-      DateTime startTime,
-      String id,
-      ) {
+    Stream<DateTime> timeStream,
+    List<Function> digits,
+    DateTime startTime,
+    String id,
+  ) {
     String timeLeftString = timeLeft.inDays.toString();
     List<Widget> rows = [];
     for (int i = 0; i < timeLeftString.toString().length; i++) {
       rows.add(
         Container(
           decoration: widget.decoration,
-          padding:
-          widget.tightLabel ? EdgeInsets.only(left: 3) : EdgeInsets.zero,
+          padding: widget.tightLabel ? EdgeInsets.only(left: 3) : EdgeInsets.zero,
           child: Digit<int>(
             padding: widget.padding,
             itemStream: timeStream.map<int>(digits[i]),
@@ -211,10 +207,10 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
   }
 
   Widget _buildHourDigits() {
-   return _buildDigit(
+    return _buildDigit(
       timeStream,
-          (DateTime time) => (timeLeft.inHours % 24) ~/ 10,
-          (DateTime time) => (timeLeft.inHours % 24) % 10,
+      (DateTime time) => (timeLeft.inHours % 24) ~/ 10,
+      (DateTime time) => (timeLeft.inHours % 24) % 10,
       DateTime.now(),
       "Hours",
     );
@@ -226,16 +222,14 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
     if (timeLeft.inDays > 99) {
       List<Function> digits = [];
       for (int i = timeLeft.inDays.toString().length - 1; i >= 0; i--) {
-        digits.add((DateTime time) =>
-            ((timeLeft.inDays) ~/ math.pow(10, i) % math.pow(10, 1)).toInt());
+        digits.add((DateTime time) => ((timeLeft.inDays) ~/ math.pow(10, i) % math.pow(10, 1)).toInt());
       }
-      dayDigits = _buildDigitForLargeNumber(
-          timeStream, digits, DateTime.now(), 'daysHundreds');
+      dayDigits = _buildDigitForLargeNumber(timeStream, digits, DateTime.now(), 'daysHundreds');
     } else {
       dayDigits = _buildDigit(
         timeStream,
-            (DateTime time) => (timeLeft.inDays) ~/ 10,
-            (DateTime time) => (timeLeft.inDays) % 10,
+        (DateTime time) => (timeLeft.inDays) ~/ 10,
+        (DateTime time) => (timeLeft.inDays) % 10,
         DateTime.now(),
         "Days",
       );
@@ -261,9 +255,7 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
           children: [
             Container(
               decoration: widget.decoration,
-              padding: widget.tightLabel
-                  ? EdgeInsets.zero
-                  : EdgeInsets.only(left: 3),
+              padding: widget.tightLabel ? EdgeInsets.zero : EdgeInsets.only(left: 3),
               child: Digit<int>(
                 padding: widget.padding,
                 itemStream: timeStream.map<int>(tensDigit),
@@ -276,9 +268,7 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
             ),
             Container(
               decoration: widget.decoration,
-              padding: widget.tightLabel
-                  ? EdgeInsets.zero
-                  : EdgeInsets.only(right: 3),
+              padding: widget.tightLabel ? EdgeInsets.zero : EdgeInsets.only(right: 3),
               child: Digit<int>(
                 padding: widget.padding,
                 itemStream: timeStream.map<int>(onesDigit),

--- a/lib/slide_countdown_clock.dart
+++ b/lib/slide_countdown_clock.dart
@@ -41,6 +41,9 @@ class SlideCountdownClock extends StatefulWidget {
   /// Whether the widget should show another division for days.
   final bool shouldShowDays;
 
+  /// Whether the widget should show the division for hours.
+  final bool shouldShowHours;
+
   SlideCountdownClock({
     Key key,
     @required this.duration,
@@ -55,25 +58,35 @@ class SlideCountdownClock extends StatefulWidget {
     this.slideDirection: SlideDirection.Down,
     this.onDone,
     this.shouldShowDays: false,
+    this.shouldShowHours: true,
     this.padding: EdgeInsets.zero,
   }) : super(key: key);
 
   @override
   SlideCountdownClockState createState() =>
-      SlideCountdownClockState(duration, shouldShowDays);
+      SlideCountdownClockState(duration, shouldShowDays, shouldShowHours);
 }
 
 class SlideCountdownClockState extends State<SlideCountdownClock> {
-  SlideCountdownClockState(Duration duration, bool shouldShowDays) {
+  SlideCountdownClockState(Duration duration, bool shouldShowDays, bool shouldShowHours) :
+        this.shouldShowDays = shouldShowDays,
+        this.shouldShowHours = shouldShowHours {
     timeLeft = duration;
-    this.shouldShowDays = shouldShowDays;
 
     if (timeLeft.inHours > 99) {
       this.shouldShowDays = true;
     }
+
+    if (timeLeft.inMinutes > 59) {
+      this.shouldShowHours = true;
+    }
+
+    this.shouldShowHours = (shouldShowHours || this.shouldShowHours) || this.shouldShowDays;
+    this.shouldShowDays = shouldShowDays || this.shouldShowDays;
   }
 
   bool shouldShowDays;
+  bool shouldShowHours;
   Duration timeLeft;
   Stream<DateTime> initStream;
   Stream<DateTime> timeStream;
@@ -113,43 +126,18 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
 
   @override
   Widget build(BuildContext context) {
-    Widget dayDigits;
-    if (timeLeft.inDays > 99) {
-      List<Function> digits = [];
-      for (int i = timeLeft.inDays.toString().length - 1; i >= 0; i--) {
-        digits.add((DateTime time) =>
-            ((timeLeft.inDays) ~/ math.pow(10, i) % math.pow(10, 1)).toInt());
-      }
-      dayDigits = _buildDigitForLargeNumber(
-          timeStream, digits, DateTime.now(), 'daysHundreds');
-    } else {
-      dayDigits = _buildDigit(
-        timeStream,
-        (DateTime time) => (timeLeft.inDays) ~/ 10,
-        (DateTime time) => (timeLeft.inDays) % 10,
-        DateTime.now(),
-        "Days",
-      );
-    }
-
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        (shouldShowDays) ? dayDigits : SizedBox(),
+        (shouldShowDays) ? _buildDayDigits() : SizedBox(),
         (shouldShowDays) ? _buildSpace() : SizedBox(),
         (widget.separator.isNotEmpty && shouldShowDays)
             ? _buildSeparator()
             : SizedBox(),
-        _buildDigit(
-          timeStream,
-          (DateTime time) => (timeLeft.inHours % 24) ~/ 10,
-          (DateTime time) => (timeLeft.inHours % 24) % 10,
-          DateTime.now(),
-          "Hours",
-        ),
-        _buildSpace(),
-        (widget.separator.isNotEmpty) ? _buildSeparator() : SizedBox(),
-        _buildSpace(),
+        (shouldShowHours) ? _buildHourDigits() : SizedBox(),
+        (shouldShowHours) ? _buildSpace() : SizedBox(),
+        (widget.separator.isNotEmpty && shouldShowHours) ? _buildSeparator() : SizedBox(),
+        (shouldShowHours) ? _buildSpace() : SizedBox(),
         _buildDigit(
           timeStream,
           (DateTime time) => (timeLeft.inMinutes % 60) ~/ 10,
@@ -220,6 +208,40 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
         ),
       ],
     );
+  }
+
+  Widget _buildHourDigits() {
+   return _buildDigit(
+      timeStream,
+          (DateTime time) => (timeLeft.inHours % 24) ~/ 10,
+          (DateTime time) => (timeLeft.inHours % 24) % 10,
+      DateTime.now(),
+      "Hours",
+    );
+  }
+
+  Widget _buildDayDigits() {
+    Widget dayDigits;
+
+    if (timeLeft.inDays > 99) {
+      List<Function> digits = [];
+      for (int i = timeLeft.inDays.toString().length - 1; i >= 0; i--) {
+        digits.add((DateTime time) =>
+            ((timeLeft.inDays) ~/ math.pow(10, i) % math.pow(10, 1)).toInt());
+      }
+      dayDigits = _buildDigitForLargeNumber(
+          timeStream, digits, DateTime.now(), 'daysHundreds');
+    } else {
+      dayDigits = _buildDigit(
+        timeStream,
+            (DateTime time) => (timeLeft.inDays) ~/ 10,
+            (DateTime time) => (timeLeft.inDays) % 10,
+        DateTime.now(),
+        "Days",
+      );
+    }
+
+    return dayDigits;
   }
 
   Widget _buildDigit(

--- a/lib/slide_countdown_clock.dart
+++ b/lib/slide_countdown_clock.dart
@@ -209,8 +209,8 @@ class SlideCountdownClockState extends State<SlideCountdownClock> {
   Widget _buildHourDigits() {
     return _buildDigit(
       timeStream,
-      (DateTime time) => (timeLeft.inHours % 24) ~/ 10,
-      (DateTime time) => (timeLeft.inHours % 24) % 10,
+      (DateTime time) => shouldShowDays ? (timeLeft.inHours % 24) ~/ 10 : timeLeft.inHours ~/ 10,
+      (DateTime time) => shouldShowDays ? (timeLeft.inHours % 24) % 10 : timeLeft.inHours % 10,
       DateTime.now(),
       "Hours",
     );


### PR DESCRIPTION
Hi! Thanks for sharing your work on this widget - I needed something very similar, but which could show just minutes and seconds if necessary, so I made the changes myself.

The new property behaves in the same way that shouldShowDays does - If the time is more than 60 minutes, it will automatically show hours, even if the property is set false.

I also fixed a bug, which caused hours to be displayed improperly if the time was more than 24 hours, but less than 99, and shouldShowDays was false: In that case it only displayed up to 24 hours, instead of up to 99.